### PR TITLE
Fixing Bug that omitted Internal TXs in CSV

### DIFF
--- a/src/export-csv.js
+++ b/src/export-csv.js
@@ -124,7 +124,6 @@ async.waterfall([
                     AND rates.currency='ETH_AETERNITY'
                     AND extract(epoch FROM rates."startTime" AT TIME zone 'utc')<transactions_eths."timeStamp" --- join on the rates
                     AND extract(epoch FROM rates."endTime" AT TIME zone 'utc')>transactions_eths."timeStamp" --- join on the rates
-                    AND confirmations > 1000
                     AND transactions_eths."timeStamp"<1491224700   --- this is just when phase 1 starts
                     AND transactions_eths."isError" is FALSE
                     
@@ -220,7 +219,6 @@ async.waterfall([
                     AND rates.currency='ETH_AETERNITY'
                     AND extract(epoch FROM rates."startTime" AT TIME zone 'utc')<transactions_eths."timeStamp" --- join on the rates
                     AND extract(epoch FROM rates."endTime" AT TIME zone 'utc')>transactions_eths."timeStamp" --- join on the rates
-                    AND confirmations > 1000
                     AND transactions_eths."timeStamp">1491224700   --- this is just when phase 1 starts
                     AND transactions_eths."timeStamp"<1496063100
                     AND transactions_eths."isError" is FALSE
@@ -350,7 +348,6 @@ async.waterfall([
                 AND rates.currency='ETH_AETERNITY'
                 AND extract(epoch FROM rates."startTime" AT TIME zone 'utc')<transactions_eths."timeStamp" --- join on the rates
                 AND extract(epoch FROM rates."endTime" AT TIME zone 'utc')>transactions_eths."timeStamp" --- join on the rates
-                AND confirmations > 1000
                 AND transactions_eths."timeStamp">1496063100 
                 AND transactions_eths."isError" is FALSE
         `).spread((results, metadata) => {


### PR DESCRIPTION
As the Etherscan API does not include the amount of confirmations for internal TXs ("action=txlistinternal"), the SQL-query excluded these TXs by mistake.

We still check for the "isError" flag.

```
MD5: 0b8a7caff697acee1593c647bddad700
SHA1: f61a75ed1f1fbad7d9f992c064f6e6066c1b5336
```